### PR TITLE
Wrap controls to prevent scrolling

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -577,7 +577,10 @@ content model =
         [ width fill
         , spacing 20
         ]
-        [ row [ spacingXY 20 0 ]
+        [ wrappedRow
+            [ width fill
+            , spacingXY 20 8
+            ]
             [ UI.button
                 []
                 { onPress = Just ResetEntries


### PR DESCRIPTION
When using small devices the controls should wrap.
