### PR TITLE
fix: incorrect timezone for edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.427.0",
     "moment": "^2.30.1",
+    "moment-timezone": "^0.5.45",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       moment:
         specifier: ^2.30.1
         version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.45
+        version: 0.5.45
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2928,6 +2931,9 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  moment-timezone@0.5.45:
+    resolution: {integrity: sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==}
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
@@ -7063,6 +7069,10 @@ snapshots:
       minimist: 1.2.8
 
   mkdirp@1.0.4: {}
+
+  moment-timezone@0.5.45:
+    dependencies:
+      moment: 2.30.1
 
   moment@2.30.1: {}
 

--- a/src/components/EditingEntry.tsx
+++ b/src/components/EditingEntry.tsx
@@ -4,6 +4,7 @@ import { Input } from "./ui/input";
 import { TableCell } from "./ui/table";
 import moment, { Moment } from "moment";
 import { CircleCheck, CircleX } from "lucide-react";
+import { momentToDatePicker } from "@/lib/utils";
 
 type EditingEntryProps = {
   item: Item;
@@ -16,7 +17,7 @@ type EditingEntryProps = {
 };
 
 export function EditingEntry(props: EditingEntryProps) {
-  const dateForInput = props.newDate.toISOString().slice(0, -1);
+  const dateForInput = momentToDatePicker(props.newDate);
   return (
     <TableCell>
       <div

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from "clsx";
+import moment, { Moment } from "moment-timezone";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export function momentToDatePicker(date: Moment): string {
+  const tz = moment.tz.guess();
+  return date.tz(tz).format("YYYY-MM-DDTHH:mm");
 }


### PR DESCRIPTION
When editing items, the date would be wrong. This is due to the incorrect timezone being used. 